### PR TITLE
Change db url line to line in app documentation

### DIFF
--- a/paclab/settings.py
+++ b/paclab/settings.py
@@ -79,11 +79,7 @@ WSGI_APPLICATION = 'paclab.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
-DATABASES = {
-    'default': dj_database_url.config(
-        default=config('DATABASE_URL')
-    )
-}
+DATABASES['default'] = dj_database_url.config(default=config('DATABASE_URL'), conn_max_age=600)
 
 
 # Password validation


### PR DESCRIPTION
I don't think this should change anything but it's worth a shot.

The documentation suggests the actual url itself needs to be four initial forward slashes followed by the absolute path.